### PR TITLE
Added canPresentCodeRedemptionSheet to Promo

### DIFF
--- a/lib/src/sdk/promo.ts
+++ b/lib/src/sdk/promo.ts
@@ -9,6 +9,14 @@ export class Promo {
   }
 
   /**
+   * @description Returns true if a sheet that enables users
+   * to redeem subscription offer codes can be displayed.
+   */
+  public canPresentCodeRedemptionSheet() {
+    return Platform.OS === "ios" && parseInt(Platform.Version as string, 10) >= 14;
+  }
+  
+  /**
    * @description Displays a sheet that enables users
    * to redeem subscription offer codes that you generated in App Store Connect.
    */


### PR DESCRIPTION
Use Case: Making it easier for developers to check if a redemption sheet can be shown or not and dynamically show UI without having to know which OS / Version combination is needed. 