### PR TITLE
Hook up RNAdaptyEvents as delegate

### DIFF
--- a/lib/ios/RNAdapty.swift
+++ b/lib/ios/RNAdapty.swift
@@ -11,6 +11,9 @@ class RNAdapty: NSObject {
   @objc static func requiresMainQueueSetup() -> Bool {
     return true
   }
+  override init() {
+    Adapty.delegate = events;
+  }
   private func cachePaywalls(_ paywalls: [PaywallModel]?) {
     self.paywalls.removeAll()
     if let paywalls = paywalls {


### PR DESCRIPTION
Currently no events are being sent as RNAdaptyEvents is not set as delegate. This PR fixes that. 