### PR TITLE
Remove console log in activate method

### DIFF
--- a/lib/src/sdk/adapty.ts
+++ b/lib/src/sdk/adapty.ts
@@ -96,7 +96,6 @@ export class Adapty extends AdaptyEventEmitter {
     Log.logLevel = logLevel || null;
 
     const ctx = new LogContext();
-    console.log('this name', this.activate.name);
     const log = ctx.call({ methodName: 'activate' });
     log.start({ apiKey, params });
 


### PR DESCRIPTION
Remove console log call in activate method.

Saw this log in my packager when updating to newest version. IMO libs should not be polluting the console by default.