### PR TITLE
Android: use reactApplicationContext.currentActivity (RN 0.81 compatibility, backwards-compatible)

### DIFF
--- a/android/src/main/kotlin/com/adapty/react/AdaptyReactModule.kt
+++ b/android/src/main/kotlin/com/adapty/react/AdaptyReactModule.kt
@@ -32,7 +32,7 @@ class AdaptyReactModule(reactContext: ReactApplicationContext) :
             },
             { value -> FileLocation.extract(value) },
         )
-        crossplatformHelper.setActivity { currentActivity }
+        crossplatformHelper.setActivity { reactApplicationContext.currentActivity }
 
     }
 


### PR DESCRIPTION
### Summary
React Native 0.81 removes direct access to `currentActivity` from ReactContextBaseJavaModule.  
This PR switches to `reactApplicationContext.currentActivity`, which works on older RN and 0.81+.

### Rationale
- Fixes build error: `Unresolved reference 'currentActivity'` on RN 0.81.

### Changes
- android: AdaptyReactModule.kt – replace `currentActivity` with `reactApplicationContext.currentActivity`.

### Testing
- Built Android example locally: clean build passes.