### PR TITLE
fix: add tslib as deps to fix compatibility with RN@0.82 create-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,11 +73,13 @@
     "react-native-config": "^1.3.3",
     "ts-jest": "^29.1.1",
     "tsc-alias": "^1.8.7",
-    "tslib": "2.6.1",
     "typedoc": "0.24.8",
     "typescript": "5.1.6",
     "react-native-testing-library": "^6.0.0",
     "react-test-renderer": "^18.2.0"
+  },
+  "dependencies": {
+    "tslib": "^2.5.0"
   },
   "peerDependencies": {
     "react-native": ">= 0.60.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5853,11 +5853,6 @@ tsc-alias@^1.8.7:
     normalize-path "^3.0.0"
     plimit-lit "^1.2.6"
 
-tslib@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
-  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -5867,6 +5862,11 @@ tslib@^2.0.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.5.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Fix compatibility with RN@0.82 create-app (react-native-community/template)

`Metro build error: UnableToResolveError: Unable to resolve module tslib from /node_modules/react-native-adapty/dist/index.js: tslib could not be found within the project or in these directories:`

