### PR TITLE
fix(mock): update payload of event did_load_latest_profile

### DIFF
--- a/src/__tests__/integration/adapty-handler/purchase-event.test.ts
+++ b/src/__tests__/integration/adapty-handler/purchase-event.test.ts
@@ -1,0 +1,64 @@
+import { Adapty } from '@/adapty-handler';
+import type { AdaptyPaywallProduct, AdaptyProfile } from '@/types';
+import { createAdaptyInstance, cleanupAdapty } from './setup.utils';
+
+describe('Adapty - Purchase Event', () => {
+  let adapty: Adapty;
+
+  beforeEach(async () => {
+    adapty = await createAdaptyInstance();
+  });
+
+  afterEach(() => {
+    cleanupAdapty(adapty);
+  });
+
+  it('should emit onLatestProfileLoad event after purchase with correct format', async () => {
+    const product: AdaptyPaywallProduct = {
+      ios: { isFamilyShareable: false },
+      vendorProductId: 'com.example.test',
+      adaptyId: 'adapty_test',
+      paywallProductIndex: 0,
+      localizedDescription: 'Test Product',
+      localizedTitle: 'Test',
+      regionCode: 'US',
+      variationId: 'variation_test',
+      paywallABTestName: 'test_ab',
+      paywallName: 'Test Paywall',
+      accessLevelId: 'test_premium',
+      productType: 'subscription',
+      payloadData: 'test_payload',
+      price: {
+        amount: 9.99,
+        currencyCode: 'USD',
+        currencySymbol: '$',
+        localizedString: '$9.99',
+      },
+    };
+
+    const profileUpdates: AdaptyProfile[] = [];
+
+    const listener = adapty.addEventListener('onLatestProfileLoad', profile => {
+      profileUpdates.push(profile);
+
+      // Verify no circular references by serializing
+      expect(() => JSON.stringify(profile)).not.toThrow();
+    });
+
+    try {
+      const result = await adapty.makePurchase(product);
+      expect(result.type).toBe('success');
+
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(profileUpdates).toHaveLength(1);
+      expect(profileUpdates[0]?.profileId).toBeDefined();
+      expect(profileUpdates[0]?.accessLevels?.['config_premium']).toBeDefined();
+      expect(
+        profileUpdates[0]?.accessLevels?.['config_premium']?.isActive,
+      ).toBe(true);
+    } finally {
+      listener.remove();
+    }
+  });
+});

--- a/src/mock/mock-request-handler.ts
+++ b/src/mock/mock-request-handler.ts
@@ -8,6 +8,7 @@ import type { AdaptyMockConfig } from './types';
 import { createMockPurchaseResult } from './mock-data';
 import { generateId } from '@/utils/generate-id';
 import { AdaptyProfileParametersCoder } from '@/coders/adapty-profile-parameters';
+import { AdaptyProfileCoder } from '@/coders/adapty-profile';
 
 type EventCallback = (...args: any[]) => void | Promise<void>;
 
@@ -146,12 +147,15 @@ export class MockRequestHandler<Method extends string, Params extends string> {
           result = createMockPurchaseResult(updatedProfile);
 
           // Emit profile update event
+          // Event format must match cross_platform.yaml: { profile: <encoded_profile> }
           setTimeout(() => {
+            const profileCoder = new AdaptyProfileCoder();
+            const encodedProfile = profileCoder.encode(updatedProfile);
             this.emitter.emit(
               'did_load_latest_profile',
-              JSON.stringify(updatedProfile),
+              JSON.stringify({ profile: encodedProfile }),
             );
-          }, 100);
+          }, 50);
           break;
 
         case 'restore_purchases':


### PR DESCRIPTION
update payload of event did_load_latest_profile to match contract.

When using mock mode and making a purchase via `adapty.makePurchase()`, the `did_load_latest_profile` event emission was failing with the error.