### PR TITLE
feat: remove manually added kotlin-stdlib dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -119,8 +119,7 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'
 
-    //noinspection DifferentStdlibGradleVersion
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    // kotlin-stdlib is added automatically by Kotlin Gradle plugin
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
remove kotlin-stdlib. The dependency is added automatically by Kotlin Gradle plugin