### PR TITLE
[breaking] Refactor/rename paywall events

### DIFF
--- a/examples/AdaptyDevtools/src/components/PaywallSection.tsx
+++ b/examples/AdaptyDevtools/src/components/PaywallSection.tsx
@@ -191,12 +191,12 @@ export const PaywallSection: React.FC<Props> = ({
         );
         return false;
       },
-      onPaywallShown() {
-        console.log('[ADAPTY]: Paywall shown');
+      onAppeared() {
+        console.log('[ADAPTY]: Paywall appeared');
         return false;
       },
-      onPaywallClosed() {
-        console.log('[ADAPTY]: Paywall closed');
+      onDisappeared() {
+        console.log('[ADAPTY]: Paywall disappeared');
         return false;
       },
     });

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@adapty/core": "3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d",
+    "@adapty/core": "4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943",
     "tslib": "^2.5.0"
   },
   "peerDependencies": {

--- a/src/__tests__/integration/ui/paywall/events/ios-paywall-view-controller-events.test.ts
+++ b/src/__tests__/integration/ui/paywall/events/ios-paywall-view-controller-events.test.ts
@@ -573,7 +573,7 @@ describe('ViewController - iOS fields absence in platform-independent events', (
 
   it('should NOT contain iOS-specific fields in events without products', async () => {
     // This test verifies that events without products don't contain iOS-specific fields
-    // For example, onPaywallShown, onPaywallClosed, etc.
+    // For example, onAppeared, onDisappeared, etc.
     // These events only contain view information, no product data
     expect(true).toBe(true); // Placeholder - actual implementation would test view-only events
   });

--- a/src/__tests__/integration/ui/paywall/events/paywall-view-controller-events.test.ts
+++ b/src/__tests__/integration/ui/paywall/events/paywall-view-controller-events.test.ts
@@ -1065,8 +1065,11 @@ describe('ViewController - multiple views isolation', () => {
   });
 
   it('should isolate event handlers between view instances', async () => {
-    // Create a second view using the SAME adapty instance
-    const { paywall: paywall2 } = await createPaywallViewController();
+    // Create a second view using the SAME adapty instance.
+    // We get paywall2 directly from the existing adapty (re-creating it via
+    // createPaywallViewController would call createAdaptyInstance again and
+    // reset the bridge, invalidating the first view's listeners).
+    const paywall2 = await adapty.getPaywall('test_placement');
     const view2 = await (view.constructor as any).create(paywall2, {});
 
     try {

--- a/src/__tests__/integration/ui/paywall/events/paywall-view-controller-events.test.ts
+++ b/src/__tests__/integration/ui/paywall/events/paywall-view-controller-events.test.ts
@@ -746,7 +746,7 @@ describe('ViewController - onCustomAction event', () => {
   });
 });
 
-describe('ViewController - onPaywallShown event', () => {
+describe('ViewController - onAppeared event', () => {
   let adapty: Adapty;
   let view: ViewController;
 
@@ -760,12 +760,12 @@ describe('ViewController - onPaywallShown event', () => {
     cleanupPaywallViewController(view, adapty);
   });
 
-  it('should call onPaywallShown handler when paywall appears', async () => {
-    const handler: jest.MockedFunction<EventHandlers['onPaywallShown']> = jest
+  it('should call onAppeared handler when paywall appears', async () => {
+    const handler: jest.MockedFunction<EventHandlers['onAppeared']> = jest
       .fn()
       .mockReturnValue(false);
 
-    view.setEventHandlers({ onPaywallShown: handler });
+    view.setEventHandlers({ onAppeared: handler });
 
     const viewId = (view as any).id;
     const sample = PAYWALL_VIEW_APPEARED;
@@ -777,7 +777,7 @@ describe('ViewController - onPaywallShown event', () => {
   });
 });
 
-describe('ViewController - onPaywallClosed event', () => {
+describe('ViewController - onDisappeared event', () => {
   let adapty: Adapty;
   let view: ViewController;
 
@@ -791,12 +791,12 @@ describe('ViewController - onPaywallClosed event', () => {
     cleanupPaywallViewController(view, adapty);
   });
 
-  it('should call onPaywallClosed handler when paywall disappears', async () => {
-    const handler: jest.MockedFunction<EventHandlers['onPaywallClosed']> = jest
+  it('should call onDisappeared handler when paywall disappears', async () => {
+    const handler: jest.MockedFunction<EventHandlers['onDisappeared']> = jest
       .fn()
       .mockReturnValue(false);
 
-    view.setEventHandlers({ onPaywallClosed: handler });
+    view.setEventHandlers({ onDisappeared: handler });
 
     const viewId = (view as any).id;
     const sample = PAYWALL_VIEW_DISAPPEARED;
@@ -1003,7 +1003,7 @@ describe('ViewController - event viewId filtering', () => {
     const onPurchaseCompletedHandler = jest.fn().mockReturnValue(false);
     const onRestoreStartedHandler = jest.fn().mockReturnValue(false);
     const onCloseHandler = jest.fn().mockReturnValue(false);
-    const onPaywallShownHandler = jest.fn().mockReturnValue(false);
+    const onAppearedHandler = jest.fn().mockReturnValue(false);
 
     // Register all handlers
     view.setEventHandlers({
@@ -1012,7 +1012,7 @@ describe('ViewController - event viewId filtering', () => {
       onPurchaseCompleted: onPurchaseCompletedHandler,
       onRestoreStarted: onRestoreStartedHandler,
       onCloseButtonPress: onCloseHandler,
-      onPaywallShown: onPaywallShownHandler,
+      onAppeared: onAppearedHandler,
     });
 
     // Use a different viewId
@@ -1046,7 +1046,7 @@ describe('ViewController - event viewId filtering', () => {
     expect(onPurchaseCompletedHandler).not.toHaveBeenCalled();
     expect(onRestoreStartedHandler).not.toHaveBeenCalled();
     expect(onCloseHandler).not.toHaveBeenCalled();
-    expect(onPaywallShownHandler).not.toHaveBeenCalled();
+    expect(onAppearedHandler).not.toHaveBeenCalled();
   });
 });
 
@@ -1372,7 +1372,7 @@ describe('ViewController - dismiss cleanup', () => {
     // Call dismiss
     await view.dismiss();
 
-    // Emit onPaywallClosed event - this triggers cleanup via internal handler
+    // Emit onDisappeared event - this triggers cleanup via internal handler
     emitPaywallViewDisappearedEvent(viewId, sample.view);
 
     // Emit events AFTER cleanup - handlers should NOT be called
@@ -1632,7 +1632,7 @@ describe('ViewController - setEventHandlers merge behavior', () => {
   });
 });
 
-describe('ViewController - onPaywallClosed after user action close', () => {
+describe('ViewController - onDisappeared after user action close', () => {
   let adapty: Adapty;
   let view: ViewController;
 
@@ -1646,7 +1646,7 @@ describe('ViewController - onPaywallClosed after user action close', () => {
     cleanupPaywallViewController(view, adapty);
   });
 
-  it('should call onPaywallClosed handler even after close button triggers dismiss', async () => {
+  it('should call onDisappeared handler even after close button triggers dismiss', async () => {
     const viewId = (view as any).id;
     const closeButtonSample = PAYWALL_USER_ACTION_CLOSE_BUTTON;
     const closedSample = PAYWALL_VIEW_DISAPPEARED;
@@ -1655,8 +1655,8 @@ describe('ViewController - onPaywallClosed after user action close', () => {
     const onCloseButtonPressHandler: jest.MockedFunction<
       EventHandlers['onCloseButtonPress']
     > = jest.fn().mockReturnValue(true); // Returns true to trigger dismiss
-    const onPaywallClosedHandler: jest.MockedFunction<
-      EventHandlers['onPaywallClosed']
+    const onDisappearedHandler: jest.MockedFunction<
+      EventHandlers['onDisappeared']
     > = jest.fn().mockReturnValue(false);
 
     // Spy on dismiss WITHOUT mocking - let it execute normally
@@ -1664,7 +1664,7 @@ describe('ViewController - onPaywallClosed after user action close', () => {
 
     view.setEventHandlers({
       onCloseButtonPress: onCloseButtonPressHandler,
-      onPaywallClosed: onPaywallClosedHandler,
+      onDisappeared: onDisappearedHandler,
     });
 
     // 1. User presses close button - this should trigger dismiss
@@ -1678,15 +1678,15 @@ describe('ViewController - onPaywallClosed after user action close', () => {
     expect(onCloseButtonPressHandler).toHaveBeenCalledTimes(1);
     expect(dismissSpy).toHaveBeenCalledTimes(1);
 
-    // 2. Native code sends onPaywallClosed before dismiss resolves
+    // 2. Native code sends onDisappeared before dismiss resolves
     // (dismiss response is expected to be the last event)
     emitPaywallViewDisappearedEvent(viewId, closedSample.view);
 
     // 3. Wait for dismiss to complete (includes cleanup)
     await dismissSpy.mock.results[0]?.value;
 
-    // VERIFICATION: onPaywallClosed handler should be called
-    expect(onPaywallClosedHandler).toHaveBeenCalledTimes(1);
+    // VERIFICATION: onDisappeared handler should be called
+    expect(onDisappearedHandler).toHaveBeenCalledTimes(1);
 
     dismissSpy.mockRestore();
   });

--- a/src/ui/AdaptyPaywallView.tsx
+++ b/src/ui/AdaptyPaywallView.tsx
@@ -26,7 +26,7 @@ export type AdaptyPaywallViewProps = ViewProps & {
   onPurchaseCompleted?: EventHandlers['onPurchaseCompleted'];
   onPurchaseFailed?: EventHandlers['onPurchaseFailed'];
   onRestoreStarted?: EventHandlers['onRestoreStarted'];
-  onPaywallShown?: EventHandlers['onPaywallShown'];
+  onAppeared?: EventHandlers['onAppeared'];
   onWebPaymentNavigationFinished?: EventHandlers['onWebPaymentNavigationFinished'];
   onRestoreCompleted?: EventHandlers['onRestoreCompleted'];
   onRestoreFailed?: EventHandlers['onRestoreFailed'];
@@ -49,7 +49,7 @@ const AdaptyPaywallViewComponent: React.FC<AdaptyPaywallViewProps> = ({
   onPurchaseCompleted,
   onPurchaseFailed,
   onRestoreStarted,
-  onPaywallShown,
+  onAppeared,
   onWebPaymentNavigationFinished,
   onRestoreCompleted,
   onRestoreFailed,
@@ -82,7 +82,7 @@ const AdaptyPaywallViewComponent: React.FC<AdaptyPaywallViewProps> = ({
         onPurchaseCompleted,
         onPurchaseFailed,
         onRestoreStarted,
-        onPaywallShown,
+        onAppeared,
         onWebPaymentNavigationFinished,
         onRestoreCompleted,
         onRestoreFailed,
@@ -98,7 +98,7 @@ const AdaptyPaywallViewComponent: React.FC<AdaptyPaywallViewProps> = ({
       onPurchaseCompleted,
       onPurchaseFailed,
       onRestoreStarted,
-      onPaywallShown,
+      onAppeared,
       onWebPaymentNavigationFinished,
       onRestoreCompleted,
       onRestoreFailed,

--- a/src/ui/create-paywall-event-handlers.test.ts
+++ b/src/ui/create-paywall-event-handlers.test.ts
@@ -71,9 +71,12 @@ describe('createPaywallEventHandlers', () => {
 
     createPaywallEventHandlers({}, 'test-id');
 
-    // Should register 6 default handlers:
-    // onCloseButtonPress, onAndroidSystemBack, onRestoreCompleted, onRenderingFailed, onPurchaseCompleted, onUrlPress
-    expect(addListener).toHaveBeenCalledTimes(6);
+    // Should register all 16 default handlers:
+    // onCloseButtonPress, onAndroidSystemBack, onUrlPress, onCustomAction,
+    // onProductSelected, onPurchaseStarted, onPurchaseCompleted, onPurchaseFailed,
+    // onRestoreStarted, onRestoreCompleted, onRestoreFailed, onAppeared,
+    // onDisappeared, onRenderingFailed, onLoadingProductsFailed, onWebPaymentNavigationFinished
+    expect(addListener).toHaveBeenCalledTimes(16);
 
     const calls = (addListener as jest.Mock).mock.calls;
     const registeredEvents = calls.map(call => call[0]);
@@ -105,8 +108,9 @@ describe('createPaywallEventHandlers', () => {
       'test-id',
     );
 
-    // Should register 6 defaults + 2 custom = 8 handlers
-    expect(addListener).toHaveBeenCalledTimes(8);
+    // 16 defaults already include onProductSelected and onPurchaseStarted,
+    // so custom handlers override defaults — total keys remain 16
+    expect(addListener).toHaveBeenCalledTimes(16);
 
     const calls = (addListener as jest.Mock).mock.calls;
     const productSelectedCall = calls.find(
@@ -182,8 +186,8 @@ describe('createPaywallEventHandlers', () => {
     expect(closeCall[1]).toBe(customCloseHandler);
     expect(restoreCall[1]).toBe(customRestoreHandler);
 
-    // Should still have only 6 handlers (not 8), because custom ones override defaults
-    expect(addListener).toHaveBeenCalledTimes(6);
+    // Should still have only 16 handlers, because custom ones override existing defaults
+    expect(addListener).toHaveBeenCalledTimes(16);
   });
 
   it('creates default onRequestClose when not provided', () => {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -36,13 +36,9 @@ import type {
 /**
  * @internal
  */
-export const DEFAULT_EVENT_HANDLERS: Partial<EventHandlers> = {
+export const DEFAULT_EVENT_HANDLERS: EventHandlers = {
   onCloseButtonPress: () => true,
   onAndroidSystemBack: () => true,
-  onRestoreCompleted: () => true,
-  onRenderingFailed: () => true,
-  onPurchaseCompleted: (purchaseResult: AdaptyPurchaseResult) =>
-    purchaseResult.type !== 'user_cancelled',
   // `Linking.openURL` always opens an external browser (i.e. `browser_out_app`).
   // To honor `browser_in_app`, override this handler
   onUrlPress: (url, openIn) => {
@@ -56,6 +52,20 @@ export const DEFAULT_EVENT_HANDLERS: Partial<EventHandlers> = {
     Linking.openURL(url);
     return false; // Keep paywall open
   },
+  onCustomAction: () => false,
+  onProductSelected: () => false,
+  onPurchaseStarted: () => false,
+  onPurchaseCompleted: (purchaseResult: AdaptyPurchaseResult) =>
+    purchaseResult.type !== 'user_cancelled',
+  onPurchaseFailed: () => false,
+  onRestoreStarted: () => false,
+  onRestoreCompleted: () => true,
+  onRestoreFailed: () => false,
+  onAppeared: () => false,
+  onDisappeared: () => false,
+  onRenderingFailed: () => true,
+  onLoadingProductsFailed: () => false,
+  onWebPaymentNavigationFinished: () => false,
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz#296d00581bfaaabfda1e976849d927824aaea81b"
   integrity sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==
 
-"@adapty/core@3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d":
-  version "3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d"
-  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-3.17.0-dev.2cd14ddac1a5989c081883c6f0cac85780d14d4d.tgz#f6cdee3bf69dde5d69354229a6e62323e417a563"
-  integrity sha512-TihxXNboLJ1dgr+xZSbofqHFUgzq9DlCCGmXF3L5MOhEUHyH3Jw1uA8vg6bySLRH5VFVeCEnQa/YL5hUXx1Oww==
+"@adapty/core@4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943":
+  version "4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943"
+  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-dev.be3bfb2d97c35a578f09706e179187ebdb312943.tgz#052151e67c9cbee48fb8755e52f8e60099a61b35"
+  integrity sha512-p/yZN2gInlMRUZFr7yuRI/cyjv7rSTf1um2AmoKIwrpyhdLXBL6V9PuJDKuakDbnqodDjPqMg180CKVwju8b+A==
   dependencies:
     tslib "^2.5.0"
 


### PR DESCRIPTION
- rename onPaywallShown/onPaywallClosed to onAppeared/onDisappeared
- make DEFAULT_EVENT_HANDLERS a full EventHandlers object