### PR TITLE
[breaking] Feat/use spm for ios

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,6 @@ name: PR Validation
 
 on:
   pull_request:
-    branches: [ master, dev ]
     types: [opened, synchronize, reopened]
   workflow_call:  # Allow this workflow to be called by other workflows
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ npx expo prebuild
 
 Read the [documentation](https://adapty.io/docs/sdk-installation-reactnative?utm_source=github&utm_medium=referral&utm_campaign=AdaptySDK-React-Native) to install and configure Adapty SDK. Set up purchases in hours instead of weeks :rocket:
 
+### iOS requirements (since 3.17)
+
+- **React Native ≥ 0.75** — required for the `spm_dependency` podspec helper that pulls the native `Adapty`, `AdaptyUI`, and `AdaptyPlugin` SDKs through Swift Package Manager.
+- **Dynamic frameworks** — your `ios/Podfile` must declare:
+
+  ```ruby
+  use_frameworks! :linkage => :dynamic
+  ```
+
+  `spm_dependency` only works with dynamic frameworks. If you currently use the default static linkage you'll need to switch — be aware this can conflict with libraries that don't yet support modular headers (see the [Callstack write-up](https://www.callstack.com/blog/integrating-swift-package-manager-with-react-native-libraries)) and is incompatible with Flipper.
+
+#### Migrating from earlier versions
+
+If you're upgrading from a version that pulled `Adapty`/`AdaptyUI`/`AdaptyPlugin` as CocoaPods sub-dependencies:
+
+1. Remove any explicit `pod 'Adapty'`, `pod 'AdaptyUI'`, `pod 'AdaptyPlugin'` lines from your `Podfile`.
+2. Add `use_frameworks! :linkage => :dynamic` to your target.
+3. Run `pod install --repo-update` from the `ios/` directory.
+
 ## Integrate IAPs within a few hours without server coding
 
 **Adapty handles everything, from free trials to refunds, in a simple, developer-friendly SDK.**

--- a/examples/AdaptyDevtools/ios/AdaptyRnSdkExample.xcodeproj/project.pbxproj
+++ b/examples/AdaptyDevtools/ios/AdaptyRnSdkExample.xcodeproj/project.pbxproj
@@ -7,12 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0C80B921A6F3F58F76C31292 /* libPods-AdaptyRnSdkExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-AdaptyRnSdkExample.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		34167C2D90E640D2812C5709 /* ios_fallback.json in Resources */ = {isa = PBXBuildFile; fileRef = 3FC0B409DB974A95B1B568AD /* ios_fallback.json */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		8437EBA135A031D05633AC4F /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
+		F0721394B90B81AC3CB9CA3F /* Pods_AdaptyRnSdkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C58D14FFF2D84A0A58C4DA1 /* Pods_AdaptyRnSdkExample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,8 +22,8 @@
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = AdaptyRnSdkExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-AdaptyRnSdkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaptyRnSdkExample.debug.xcconfig"; path = "Target Support Files/Pods-AdaptyRnSdkExample/Pods-AdaptyRnSdkExample.debug.xcconfig"; sourceTree = "<group>"; };
 		3FC0B409DB974A95B1B568AD /* ios_fallback.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = ios_fallback.json; path = ../assets/ios/ios_fallback.json; sourceTree = "<group>"; };
+		4C58D14FFF2D84A0A58C4DA1 /* Pods_AdaptyRnSdkExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdaptyRnSdkExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5709B34CF0A7D63546082F79 /* Pods-AdaptyRnSdkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AdaptyRnSdkExample.release.xcconfig"; path = "Target Support Files/Pods-AdaptyRnSdkExample/Pods-AdaptyRnSdkExample.release.xcconfig"; sourceTree = "<group>"; };
-		5DCACB8F33CDC322A6C60F78 /* libPods-AdaptyRnSdkExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AdaptyRnSdkExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = AdaptyRnSdkExample/AppDelegate.swift; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = AdaptyRnSdkExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -34,7 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0C80B921A6F3F58F76C31292 /* libPods-AdaptyRnSdkExample.a in Frameworks */,
+				F0721394B90B81AC3CB9CA3F /* Pods_AdaptyRnSdkExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,7 +57,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5DCACB8F33CDC322A6C60F78 /* libPods-AdaptyRnSdkExample.a */,
+				4C58D14FFF2D84A0A58C4DA1 /* Pods_AdaptyRnSdkExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -373,6 +373,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_ROOT}/ReactCommon",
+					"${PODS_ROOT}/ReactCommon/react/nativemodule/core",
+					"${PODS_ROOT}/React-runtimeexecutor",
+					"${PODS_ROOT}/React-runtimeexecutor/platform/ios",
+					"${PODS_ROOT}/ReactCommon-Samples",
+					"${PODS_ROOT}/ReactCommon-Samples/platform/ios",
+					"${PODS_ROOT}/React-Fabric/react/renderer/components/view/platform/cxx",
+					"${PODS_ROOT}/React-NativeModulesApple",
+					"${PODS_ROOT}/React-graphics",
+					"${PODS_ROOT}/React-graphics/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -452,6 +465,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_ROOT}/ReactCommon",
+					"${PODS_ROOT}/ReactCommon/react/nativemodule/core",
+					"${PODS_ROOT}/React-runtimeexecutor",
+					"${PODS_ROOT}/React-runtimeexecutor/platform/ios",
+					"${PODS_ROOT}/ReactCommon-Samples",
+					"${PODS_ROOT}/ReactCommon-Samples/platform/ios",
+					"${PODS_ROOT}/React-Fabric/react/renderer/components/view/platform/cxx",
+					"${PODS_ROOT}/React-NativeModulesApple",
+					"${PODS_ROOT}/React-graphics",
+					"${PODS_ROOT}/React-graphics/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,

--- a/examples/AdaptyDevtools/ios/AdaptyRnSdkExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/AdaptyDevtools/ios/AdaptyRnSdkExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "669e39cee4b9a959079c644a4b709931519220e990aef01ed70964c38e5631c3",
+  "pins" : [
+    {
+      "identity" : "adaptysdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adaptyteam/AdaptySDK-iOS.git",
+      "state" : {
+        "revision" : "4c316ffacb55efb4831998059e0e460b2c7855a5",
+        "version" : "3.17.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/examples/AdaptyDevtools/ios/AdaptyRnSdkExample/PrivacyInfo.xcprivacy
+++ b/examples/AdaptyDevtools/ios/AdaptyRnSdkExample/PrivacyInfo.xcprivacy
@@ -6,18 +6,18 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>CA92.1</string>
-			</array>
-		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
 				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/examples/AdaptyDevtools/ios/Podfile
+++ b/examples/AdaptyDevtools/ios/Podfile
@@ -8,11 +8,8 @@ require Pod::Executable.execute_command('node', ['-p',
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-linkage = ENV['USE_FRAMEWORKS']
-if linkage != nil
-  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
-  use_frameworks! :linkage => linkage.to_sym
-end
+# Required for spm_dependency in react-native-adapty (RN 0.75+ SPM integration).
+use_frameworks! :linkage => :dynamic
 
 target 'AdaptyRnSdkExample' do
   config = use_native_modules!

--- a/examples/AdaptyDevtools/ios/Podfile.lock
+++ b/examples/AdaptyDevtools/ios/Podfile.lock
@@ -1,19 +1,4 @@
 PODS:
-  - Adapty (3.17.0):
-    - AdaptyLogger (= 3.17.0)
-    - AdaptyUIBuilder (= 3.17.0)
-  - AdaptyLogger (3.17.0)
-  - AdaptyPlugin (3.17.0):
-    - Adapty (= 3.17.0)
-    - AdaptyLogger (= 3.17.0)
-    - AdaptyUI (= 3.17.0)
-    - AdaptyUIBuilder (= 3.17.0)
-  - AdaptyUI (3.17.0):
-    - Adapty (= 3.17.0)
-    - AdaptyLogger (= 3.17.0)
-    - AdaptyUIBuilder (= 3.17.0)
-  - AdaptyUIBuilder (3.17.0):
-    - AdaptyLogger (= 3.17.0)
   - FBLazyVector (0.84.1)
   - hermes-engine (250829098.0.9):
     - hermes-engine/Pre-built (= 250829098.0.9)
@@ -1415,11 +1400,28 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-adapty-sdk (3.15.6):
-    - Adapty (= 3.17.0)
-    - AdaptyPlugin (= 3.17.0)
-    - AdaptyUI (= 3.17.0)
-    - React
+  - react-native-adapty-sdk (3.17.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - react-native-safe-area-context (5.7.0):
     - hermes-engine
     - RCTRequired
@@ -2002,14 +2004,6 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
-SPEC REPOS:
-  trunk:
-    - Adapty
-    - AdaptyLogger
-    - AdaptyPlugin
-    - AdaptyUI
-    - AdaptyUIBuilder
-
 EXTERNAL SOURCES:
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
@@ -2166,11 +2160,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Adapty: ae0038fac37a10f3916824b508578be0459d03ea
-  AdaptyLogger: 8de7cf207476715ef97c1f5d5b1476af21dc8691
-  AdaptyPlugin: 67b9afd1639599f808eb707341f6ce0418e02a3d
-  AdaptyUI: 6f0fd0494bed813952bd3008cbbd0ff8b961ecbb
-  AdaptyUIBuilder: c2f9e2b57383d7945ab912d9cf78ebd6ee0c3652
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
   hermes-engine: 34d77201bbd87065e48e077de1de09caea442154
   RCTDeprecation: af44b104091a34482596cd9bd7e8d90c4e9b4bd7
@@ -2181,73 +2170,73 @@ SPEC CHECKSUMS:
   React: 1ba7d364ade7d883a1ec055bfc3606f35fdee17b
   React-callinvoker: bc2a26f8d84fb01f003fc6de6c9337b64715f95b
   React-Core: 7840d3a80b43a95c5e80ef75146bd70925ebab0f
-  React-Core-prebuilt: eb403aaccb34127adb2bf0b96b1e441984e7dc11
+  React-Core-prebuilt: ca83b451ef7fa9524f24d74b04b9f3135098b148
   React-CoreModules: 2eb010400b63b89e53a324ffb3c112e4c7c3ce42
   React-cxxreact: a558e92199d26f145afa9e62c4233cf8e7950efe
-  React-debug: 755200a6e7f5e6e0a40ff8d215493d43cce285fc
-  React-defaultsnativemodule: bb85b1bdd9b4b82650cfa92998567fcfdb030145
-  React-domnativemodule: ffdba8ba4323387e821d8298be2013516036df87
-  React-Fabric: 8705ba7f14acf5b1df474d1af4b0191c69ac4690
-  React-FabricComponents: 5a1b5007fe8c5d5f043e45c335ebef2af0717fb2
-  React-FabricImage: e96eea6bb65b501cf5db3ce4ad057a97dea1dd69
-  React-featureflags: 410f6c383eb94019f63f105374d738169df291ae
-  React-featureflagsnativemodule: 5d6d7931ec5d4576639661c0f79169a0ae383023
-  React-graphics: b9b69adbe79d6944838aa304c849d78f977e9f21
+  React-debug: d196e6df0599d78360b3211367e28c5583054133
+  React-defaultsnativemodule: fb293625c6bb890a9a546edcf80f946f67908aaf
+  React-domnativemodule: 16e331f3bef280db2da6a3d1ce23c67a094e6a2e
+  React-Fabric: d3634fbca73bf4f0be4b3e871b4eb1550297e657
+  React-FabricComponents: a718c092b5cdd75c0cd85dae479f74277a66653c
+  React-FabricImage: 4277dba3b575ba7d215fa3683676c644f090ce87
+  React-featureflags: d2f82cf0f0e711e6a4175541534144b89cbbd2f3
+  React-featureflagsnativemodule: 7fd86a2320e38cdbbdcd66af50497fcc215f1dd3
+  React-graphics: dc425d5fef7f7d989b3265dac8c461caa79b6abd
   React-hermes: 666c66bbc856b46dfa4b132f1c9efaa37ad419a1
-  React-idlecallbacksnativemodule: 785d307b9236ec9fb4ec0bcf99b34e8539d2d76e
-  React-ImageManager: daeef8b1c19803c71a9233f21f7f235cd3ec294e
-  React-intersectionobservernativemodule: c17189d2350205012682aefe566f7ebaa4f980e3
-  React-jserrorhandler: 431377b3d1783127bc394986fe8d932bcb8982fe
+  React-idlecallbacksnativemodule: ea2287291065049ca055b4cb4f10a2570ddaa28c
+  React-ImageManager: e187eb7a2a7ca0a9b39699cecc9c8df427695613
+  React-intersectionobservernativemodule: 000f27429f2c8806a75bfb1c59855f1a647fb0d4
+  React-jserrorhandler: ea7af8d511c4016fff7618c6cb71c304b60e479c
   React-jsi: 33db13b95bb53827b03d9fb0f567d12b63dfc8ef
   React-jsiexecutor: 49de4d48a7c4f283eaa865f7a4f3919f2c39be1c
-  React-jsinspector: 3ec7dd478806a0eb4ec6ab394e51a395e8f895ba
-  React-jsinspectorcdp: bcb79a666959b1a3e8aac3ff8209d05c719aaa2a
-  React-jsinspectornetwork: be3b81a6342b56c74dd0bdd58bf3f62f978c1472
-  React-jsinspectortracing: 293251deadf7c255da593bf1d9d337a645abdfdc
-  React-jsitooling: 6f729cdb85ff0c8294709ec1903e1f0c59662331
-  React-jsitracing: be95d903cc9440ab89a704c999dd7db6675dc47f
+  React-jsinspector: 3ca9fe04f09c16dc8d3a5b8839b43404c36ea6b7
+  React-jsinspectorcdp: 53a9f8d9d03509469493c4ef910fec81a4b8de58
+  React-jsinspectornetwork: dc5ee29afca54564ee6c6470872aaebe0b672309
+  React-jsinspectortracing: c1fa5b8b1e3c7faef3c2816b032023d5e065dd6d
+  React-jsitooling: 0995909d465f0942f921d39563816ca31a1820a6
+  React-jsitracing: 2bf43db3d78775cf35ffc5c3a622cdb2f8ddbcb7
   React-logger: b5521614afb8690420146dfc61a1447bb5d65419
-  React-Mapbuffer: f4ee8c62e0ef8359d139124f35a471518a172cd3
-  React-microtasksnativemodule: d1956f0eec54c619b63a379520fb4c618a55ccb9
-  react-native-adapty-sdk: 77e605ee0d1dc9178baf018b06a6ecb1a9dc2660
-  react-native-safe-area-context: ae7587b95fb580d1800c5b0b2a7bd48c2868e67a
+  React-Mapbuffer: 0db00b587a6a6f0f6813e9fb2655e337261f513e
+  React-microtasksnativemodule: 7ccd4c74006eec09a2df88ca31ba8b0c22c50a4d
+  react-native-adapty-sdk: 12e9ac151226eb50547df5ea882a66fcd2049273
+  react-native-safe-area-context: 90476586077446d5eab1d41ac3e767b016ac41d6
   React-NativeModulesApple: 5ba0903927f6b8d335a091700e9fda143980f819
-  React-networking: 3a4b7f9ed2b2d1c0441beacb79674323a24bcca6
+  React-networking: ad2727500e93943a43da70d3b162454af151469c
   React-oscompat: ff26abf0ae3e3fdbe47b44224571e3fc7226a573
   React-perflogger: a86b2146936f2ffa80188425c6e8892729e2ad01
-  React-performancecdpmetrics: 65b699c3e52c0a1d978d9cdf15e60c62e335b900
-  React-performancetimeline: b44f82caa563e46068d02d9cf5b0d2b84bdc7a6a
+  React-performancecdpmetrics: 85976f9321ae685d1cbc3b842308f046ad4968d8
+  React-performancetimeline: 521f72baddea6d8ff259d5d7dc5d7b31bf1a6a69
   React-RCTActionSheet: fc1d5d419856868e7f8c13c14591ed63dadef43a
   React-RCTAnimation: 2a1e7eeb55b71e8524db296fa31e46eeaa2d0da4
   React-RCTAppDelegate: 317c1102a2d0bcc07567d8de58d9147102080b0e
   React-RCTBlob: c82bbf96b2d1389550c05fb9739d4e85d471052e
-  React-RCTFabric: d82ad8120ba70fe63207e261b9e33d9b6077e2de
-  React-RCTFBReactNativeSpec: 4d33b5f3b339e9fa902168e8a1d62c458dda16e9
+  React-RCTFabric: 01f5cd463bd82260358b8667328a8e0f73cfc1d3
+  React-RCTFBReactNativeSpec: 2db8b42782377838f4b3a8c51ab5d6f1c487c942
   React-RCTImage: f959463e53ea731ab267e371eea1b92fccf27634
   React-RCTLinking: 2a857113b8059ac4f0a8ae89f8aa312837b955d0
   React-RCTNetwork: dc026bf25f6457249349be8cf8bd5fdf84cdfb14
-  React-RCTRuntime: b0630731fd864064066301e1e31406fea606d5f9
+  React-RCTRuntime: 205340a02f49c8937a372e4e9eaa296987d8445d
   React-RCTSettings: e159e19475df2e92fd3b4ddcfe29f6cc12cf0ee4
   React-RCTText: 7356cc84c2ed79635931891c176f72e0289dc75d
   React-RCTVibration: 77621175b67b22e655ce4b29d1cda8498f2033e7
-  React-rendererconsistency: e91aba4bb482dac127ad955dba6333a8af629c5b
-  React-renderercss: 7cc41efaecf557d7b70edaa08fad5ace79f714f6
-  React-rendererdebug: 0f004cbed7b4c27327423be47209770830bf3c6d
-  React-RuntimeApple: 6f4ff8e2d8b05cb3ceabf57e494c04da8751f009
-  React-RuntimeCore: 25be9c7025eabb524cd00dbb6ce56d6b122e3d92
-  React-runtimeexecutor: 84d394b9f0a8fc7dab8a98bf88a43228bb04dac2
-  React-RuntimeHermes: 2bed5b2d2419945cc5c2f6d627a1b46ce3a0f66a
-  React-runtimescheduler: 23b092dbcd3088f9c947551c23366dd00254caf3
-  React-timing: 2ab9ccd4b41aa171090c16f664f6c5bfb2fd0ddc
-  React-utils: 8d888b379f0808bfabaea03d85f9e8dd9b8548da
-  React-webperformancenativemodule: c10016db7f1bb1153060d4aa9f7dbde2c88c845d
+  React-rendererconsistency: fba8b761416e5321021366efce596d530e0c558b
+  React-renderercss: 8d9876f64a5ee6fea6d91617f4909e1bd153cc78
+  React-rendererdebug: 5d63ef4df4712687ccef8a4bf6b15ef018a974bb
+  React-RuntimeApple: 1cf8a27ae270d27bf6e819ab448d0155e4ac210a
+  React-RuntimeCore: 2ae912c0af9a1898560c69c1e4b6daca2e63342c
+  React-runtimeexecutor: 8d9a79a97e2826e5017bc4aadb00a1d7d69d252b
+  React-RuntimeHermes: 83eecb1fb796090a4b57f9a5a0cef62114885708
+  React-runtimescheduler: c45208e3506c717c0700023aede07c1ca271763f
+  React-timing: 2f65f30369ed4cd7c5356135dd160d0710a95257
+  React-utils: 7ace4a70a287291541c646e3f02688ba439ed743
+  React-webperformancenativemodule: 4b56d01c3a3f403231c3756ac7031db8ab64f504
   ReactAppDependencyProvider: e96e93b493d8d86eeaee3e590ba0be53f6abe46f
-  ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
+  ReactCodegen: 66522f37c7e4861aec1f6a574dee83917fad4397
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
   ReactNativeDependencies: 00c22c3a991dbd4239d7766f826d5c5b586b4d56
-  RNScreens: 6cb648bdad8fe9bee9259fe144df95b6d1d5b707
-  Yoga: 7c1c3b93e408ac46c7ed64b5641ca7161747378d
+  RNScreens: ca829379d20b0d1ff41a0b87bc37bdc50276cef5
+  Yoga: 54ad1f177695cddea2c5090897cce963a0650d93
 
-PODFILE CHECKSUM: a38e1e23734ffa12f5faa704a5a8cdb4c7902d46
+PODFILE CHECKSUM: c17743949ef390c69cd4b9e08146e7d002de35f5
 
 COCOAPODS: 1.15.2

--- a/examples/AdaptyDevtools/package.json
+++ b/examples/AdaptyDevtools/package.json
@@ -7,7 +7,7 @@
     "credentials-force": "node ../../scripts/credentials.js --force-bundle",
     "prestart": "yarn credentials",
     "update-sdk-full": "../../scripts/build_and_install_pack.zsh",
-    "update-native-modules": "cd ./ios && pod update Adapty AdaptyUI AdaptyPlugin",
+    "update-native-modules": "cd ./ios && pod install --repo-update",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",

--- a/examples/FocusJournalExpo/app.json
+++ b/examples/FocusJournalExpo/app.json
@@ -46,6 +46,14 @@
             "android": "./assets/android_fallback.json"
           }
         }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "useFrameworks": "dynamic"
+          }
+        }
       ]
     ]
   }

--- a/examples/FocusJournalExpo/ios/FocusJournalExpo.xcodeproj/project.pbxproj
+++ b/examples/FocusJournalExpo/ios/FocusJournalExpo.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		044F18165227EEAE468751D8 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 414508EAE6978623B5634FF1 /* ExpoModulesProvider.swift */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
-		547EB25F796F855C35B76F1D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 7AC2F6AF043E4C2AC8574964 /* PrivacyInfo.xcprivacy */; };
-		8122AF26347740CBA97232D7 /* ios_fallback.json in Resources */ = {isa = PBXBuildFile; fileRef = A4BBB7C14184453A883323DB /* ios_fallback.json */; };
+		8032D1459EC014343B8EB365 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 230D277B5BF72A5401E4EF36 /* PrivacyInfo.xcprivacy */; };
+		B34DA14B8C5D3871C8534D58 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222D023E03ECC5D8DC56962E /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		ED1B9050B87BB16B000AA41B /* libPods-FocusJournalExpo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A4D4AF352C097250DF02AF9 /* libPods-FocusJournalExpo.a */; };
+		D8F65A8784414003AF2AE7F3 /* ios_fallback.json in Resources */ = {isa = PBXBuildFile; fileRef = 870E733B3C0A4C1691149177 /* ios_fallback.json */; };
+		EEDEB0C1091330E6C9E2D9B9 /* Pods_FocusJournalExpo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EADDD98D463260C2E4AA657D /* Pods_FocusJournalExpo.framework */; };
 		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -21,14 +21,14 @@
 		13B07F961A680F5B00A75B9A /* FocusJournalExpo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FocusJournalExpo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = FocusJournalExpo/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = FocusJournalExpo/Info.plist; sourceTree = "<group>"; };
-		414508EAE6978623B5634FF1 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-FocusJournalExpo/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
-		5B7763E3EBE33D282DF6E497 /* Pods-FocusJournalExpo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FocusJournalExpo.debug.xcconfig"; path = "Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo.debug.xcconfig"; sourceTree = "<group>"; };
-		6A4D4AF352C097250DF02AF9 /* libPods-FocusJournalExpo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FocusJournalExpo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		7AC2F6AF043E4C2AC8574964 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = FocusJournalExpo/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		A4BBB7C14184453A883323DB /* ios_fallback.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = ios_fallback.json; path = ../assets/ios_fallback.json; sourceTree = "<group>"; };
+		222D023E03ECC5D8DC56962E /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-FocusJournalExpo/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		230D277B5BF72A5401E4EF36 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = FocusJournalExpo/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		706E1B6CE24D0EC18A8CE8AB /* Pods-FocusJournalExpo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FocusJournalExpo.debug.xcconfig"; path = "Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo.debug.xcconfig"; sourceTree = "<group>"; };
+		870E733B3C0A4C1691149177 /* ios_fallback.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = ios_fallback.json; path = ../assets/ios_fallback.json; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = FocusJournalExpo/SplashScreen.storyboard; sourceTree = "<group>"; };
+		B9DB2361B99E34938DE5A3C7 /* Pods-FocusJournalExpo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FocusJournalExpo.release.xcconfig"; path = "Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo.release.xcconfig"; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
-		D157972F6FEACD66C6C883A3 /* Pods-FocusJournalExpo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FocusJournalExpo.release.xcconfig"; path = "Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo.release.xcconfig"; sourceTree = "<group>"; };
+		EADDD98D463260C2E4AA657D /* Pods_FocusJournalExpo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FocusJournalExpo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = FocusJournalExpo/AppDelegate.swift; sourceTree = "<group>"; };
 		F11748442D0722820044C1D9 /* FocusJournalExpo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "FocusJournalExpo-Bridging-Header.h"; path = "FocusJournalExpo/FocusJournalExpo-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -39,7 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED1B9050B87BB16B000AA41B /* libPods-FocusJournalExpo.a in Frameworks */,
+				EEDEB0C1091330E6C9E2D9B9 /* Pods_FocusJournalExpo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,42 +55,41 @@
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				7AC2F6AF043E4C2AC8574964 /* PrivacyInfo.xcprivacy */,
+				230D277B5BF72A5401E4EF36 /* PrivacyInfo.xcprivacy */,
 			);
 			name = FocusJournalExpo;
-			sourceTree = "<group>";
-		};
-		1ABAA1D1ACC94AB283DF99E5 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				A4BBB7C14184453A883323DB /* ios_fallback.json */,
-			);
-			name = Resources;
-			path = "";
 			sourceTree = "<group>";
 		};
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				6A4D4AF352C097250DF02AF9 /* libPods-FocusJournalExpo.a */,
+				EADDD98D463260C2E4AA657D /* Pods_FocusJournalExpo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		46153774E0450CA08F5ACE91 /* FocusJournalExpo */ = {
+		32088F71AE30B47C1B18D2C0 /* FocusJournalExpo */ = {
 			isa = PBXGroup;
 			children = (
-				414508EAE6978623B5634FF1 /* ExpoModulesProvider.swift */,
+				222D023E03ECC5D8DC56962E /* ExpoModulesProvider.swift */,
 			);
 			name = FocusJournalExpo;
 			sourceTree = "<group>";
 		};
-		5FD9575E4CA377C6EB7924B3 /* Pods */ = {
+		3D3C16A9F4DDAE0609FB9AC7 /* ExpoModulesProviders */ = {
 			isa = PBXGroup;
 			children = (
-				5B7763E3EBE33D282DF6E497 /* Pods-FocusJournalExpo.debug.xcconfig */,
-				D157972F6FEACD66C6C883A3 /* Pods-FocusJournalExpo.release.xcconfig */,
+				32088F71AE30B47C1B18D2C0 /* FocusJournalExpo */,
+			);
+			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
+		6947C6E3698AC567A5973EC1 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				706E1B6CE24D0EC18A8CE8AB /* Pods-FocusJournalExpo.debug.xcconfig */,
+				B9DB2361B99E34938DE5A3C7 /* Pods-FocusJournalExpo.release.xcconfig */,
 			);
 			name = Pods;
 			path = Pods;
@@ -110,9 +109,9 @@
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
-				1ABAA1D1ACC94AB283DF99E5 /* Resources */,
-				5FD9575E4CA377C6EB7924B3 /* Pods */,
-				AB51263DE7E40211C2002922 /* ExpoModulesProviders */,
+				BFB0F1D2803E461FB75296DB /* Resources */,
+				6947C6E3698AC567A5973EC1 /* Pods */,
+				3D3C16A9F4DDAE0609FB9AC7 /* ExpoModulesProviders */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -127,14 +126,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		AB51263DE7E40211C2002922 /* ExpoModulesProviders */ = {
-			isa = PBXGroup;
-			children = (
-				46153774E0450CA08F5ACE91 /* FocusJournalExpo */,
-			);
-			name = ExpoModulesProviders;
-			sourceTree = "<group>";
-		};
 		BB2F792B24A3F905000567C9 /* Supporting */ = {
 			isa = PBXGroup;
 			children = (
@@ -142,6 +133,15 @@
 			);
 			name = Supporting;
 			path = FocusJournalExpo/Supporting;
+			sourceTree = "<group>";
+		};
+		BFB0F1D2803E461FB75296DB /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				870E733B3C0A4C1691149177 /* ios_fallback.json */,
+			);
+			name = Resources;
+			path = "";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -152,13 +152,13 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "FocusJournalExpo" */;
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
-				284BF07BD51CA46D8EA9A759 /* [Expo] Configure project */,
+				4472A3A035252A210B869AE2 /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				B29F07D588085A875E23C606 /* [CP] Embed Pods Frameworks */,
+				BBCE8868425C41DE296421ED /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -208,8 +208,8 @@
 				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
-				8122AF26347740CBA97232D7 /* ios_fallback.json in Resources */,
-				547EB25F796F855C35B76F1D /* PrivacyInfo.xcprivacy in Resources */,
+				D8F65A8784414003AF2AE7F3 /* ios_fallback.json in Resources */,
+				8032D1459EC014343B8EB365 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -255,7 +255,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		284BF07BD51CA46D8EA9A759 /* [Expo] Configure project */ = {
+		4472A3A035252A210B869AE2 /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -286,8 +286,6 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/Adapty/Adapty.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/AdaptyUI/AdaptyUI.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
@@ -298,8 +296,6 @@
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Adapty.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AdaptyUI.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
@@ -313,19 +309,27 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B29F07D588085A875E23C606 /* [CP] Embed Pods Frameworks */ = {
+		BBCE8868425C41DE296421ED /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-FocusJournalExpo/Pods-FocusJournalExpo-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/RNScreens/RNScreens.framework",
+				"${BUILT_PRODUCTS_DIR}/ReactCodegen/ReactCodegen.framework",
+				"${BUILT_PRODUCTS_DIR}/react-native-adapty-sdk/react_native_adapty_sdk.framework",
+				"${BUILT_PRODUCTS_DIR}/react-native-safe-area-context/react_native_safe_area_context.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt/React.framework/React",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies/ReactNativeDependencies.framework/ReactNativeDependencies",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNScreens.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactCodegen.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_adapty_sdk.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_safe_area_context.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactNativeDependencies.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
@@ -343,7 +347,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
-				044F18165227EEAE468751D8 /* ExpoModulesProvider.swift in Sources */,
+				B34DA14B8C5D3871C8534D58 /* ExpoModulesProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -352,7 +356,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B7763E3EBE33D282DF6E497 /* Pods-FocusJournalExpo.debug.xcconfig */;
+			baseConfigurationReference = 706E1B6CE24D0EC18A8CE8AB /* Pods-FocusJournalExpo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -377,7 +381,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adapty.adaptydemoapp;
-				PRODUCT_NAME = "FocusJournalExpo";
+				PRODUCT_NAME = FocusJournalExpo;
 				SWIFT_OBJC_BRIDGING_HEADER = "FocusJournalExpo/FocusJournalExpo-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -388,7 +392,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D157972F6FEACD66C6C883A3 /* Pods-FocusJournalExpo.release.xcconfig */;
+			baseConfigurationReference = B9DB2361B99E34938DE5A3C7 /* Pods-FocusJournalExpo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -408,7 +412,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adapty.adaptydemoapp;
-				PRODUCT_NAME = "FocusJournalExpo";
+				PRODUCT_NAME = FocusJournalExpo;
 				SWIFT_OBJC_BRIDGING_HEADER = "FocusJournalExpo/FocusJournalExpo-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -463,6 +467,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_ROOT}/ReactCommon",
+					"${PODS_ROOT}/ReactCommon/react/nativemodule/core",
+					"${PODS_ROOT}/React-runtimeexecutor",
+					"${PODS_ROOT}/React-runtimeexecutor/platform/ios",
+					"${PODS_ROOT}/ReactCommon-Samples",
+					"${PODS_ROOT}/ReactCommon-Samples/platform/ios",
+					"${PODS_ROOT}/React-Fabric/react/renderer/components/view/platform/cxx",
+					"${PODS_ROOT}/React-NativeModulesApple",
+					"${PODS_ROOT}/React-graphics",
+					"${PODS_ROOT}/React-graphics/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
@@ -519,6 +536,19 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_ROOT}/ReactCommon",
+					"${PODS_ROOT}/ReactCommon/react/nativemodule/core",
+					"${PODS_ROOT}/React-runtimeexecutor",
+					"${PODS_ROOT}/React-runtimeexecutor/platform/ios",
+					"${PODS_ROOT}/ReactCommon-Samples",
+					"${PODS_ROOT}/ReactCommon-Samples/platform/ios",
+					"${PODS_ROOT}/React-Fabric/react/renderer/components/view/platform/cxx",
+					"${PODS_ROOT}/React-NativeModulesApple",
+					"${PODS_ROOT}/React-graphics",
+					"${PODS_ROOT}/React-graphics/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,

--- a/examples/FocusJournalExpo/ios/FocusJournalExpo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/FocusJournalExpo/ios/FocusJournalExpo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "669e39cee4b9a959079c644a4b709931519220e990aef01ed70964c38e5631c3",
+  "pins" : [
+    {
+      "identity" : "adaptysdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adaptyteam/AdaptySDK-iOS.git",
+      "state" : {
+        "revision" : "4c316ffacb55efb4831998059e0e460b2c7855a5",
+        "version" : "3.17.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/examples/FocusJournalExpo/ios/FocusJournalExpo/PrivacyInfo.xcprivacy
+++ b/examples/FocusJournalExpo/ios/FocusJournalExpo/PrivacyInfo.xcprivacy
@@ -17,9 +17,9 @@
 			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>C617.1</string>
 				<string>0A2A.1</string>
 				<string>3B52.1</string>
+				<string>C617.1</string>
 			</array>
 		</dict>
 		<dict>

--- a/examples/FocusJournalExpo/ios/Podfile.lock
+++ b/examples/FocusJournalExpo/ios/Podfile.lock
@@ -1,19 +1,4 @@
 PODS:
-  - Adapty (3.17.0):
-    - AdaptyLogger (= 3.17.0)
-    - AdaptyUIBuilder (= 3.17.0)
-  - AdaptyLogger (3.17.0)
-  - AdaptyPlugin (3.17.0):
-    - Adapty (= 3.17.0)
-    - AdaptyLogger (= 3.17.0)
-    - AdaptyUI (= 3.17.0)
-    - AdaptyUIBuilder (= 3.17.0)
-  - AdaptyUI (3.17.0):
-    - Adapty (= 3.17.0)
-    - AdaptyLogger (= 3.17.0)
-    - AdaptyUIBuilder (= 3.17.0)
-  - AdaptyUIBuilder (3.17.0):
-    - AdaptyLogger (= 3.17.0)
   - EXConstants (18.0.10):
     - ExpoModulesCore
   - EXJSONUtils (0.15.0)
@@ -185,6 +170,7 @@ PODS:
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-rendererconsistency
     - React-renderercss
     - React-rendererdebug
     - React-utils
@@ -1534,10 +1520,27 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
   - react-native-adapty-sdk (3.17.0):
-    - Adapty (= 3.17.0)
-    - AdaptyPlugin (= 3.17.0)
-    - AdaptyUI (= 3.17.0)
-    - React
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - react-native-safe-area-context (5.4.0):
     - hermes-engine
     - RCTRequired
@@ -2094,14 +2097,6 @@ DEPENDENCIES:
   - RNScreens (from `../node_modules/react-native-screens`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
-SPEC REPOS:
-  trunk:
-    - Adapty
-    - AdaptyLogger
-    - AdaptyPlugin
-    - AdaptyUI
-    - AdaptyUIBuilder
-
 EXTERNAL SOURCES:
   EXConstants:
     :path: "../node_modules/expo/node_modules/expo-constants/ios"
@@ -2276,24 +2271,19 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Adapty: ae0038fac37a10f3916824b508578be0459d03ea
-  AdaptyLogger: 8de7cf207476715ef97c1f5d5b1476af21dc8691
-  AdaptyPlugin: 67b9afd1639599f808eb707341f6ce0418e02a3d
-  AdaptyUI: 6f0fd0494bed813952bd3008cbbd0ff8b961ecbb
-  AdaptyUIBuilder: c2f9e2b57383d7945ab912d9cf78ebd6ee0c3652
   EXConstants: fd688cef4e401dcf798a021cfb5d87c890c30ba3
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 224345a575fca389073c416297b6348163f28d1a
-  Expo: c524bec66bed697b2140037e2ba110b3a8281b78
+  Expo: 1eae5a52f4532767fc1c40eb4cca4f202d88db1e
   expo-dev-client: 974463bca58c100a32f099450e9413893bee3de8
-  expo-dev-launcher: adcbbff3464b908458255d0fdf3e8cf79c67d614
-  expo-dev-menu: 78e39c8cca65695b7ccb2c70c618043137f6735c
+  expo-dev-launcher: 91df29074be55c060f7ee04f8fa9e454057be647
+  expo-dev-menu: d423a8b6623003532e1b303febe978c16e9ce362
   expo-dev-menu-interface: 600df12ea01efecdd822daaf13cc0ac091775533
   ExpoAsset: 9ba6fbd677fb8e241a3899ac00fa735bc911eadf
   ExpoFileSystem: b79eadbda7b7f285f378f95f959cc9313a1c9c61
   ExpoFont: cf9d90ec1d3b97c4f513211905724c8171f82961
   ExpoKeepAwake: 1a2e820692e933c94a565ec3fbbe38ac31658ffe
-  ExpoModulesCore: d128da9ae4ec1e5a26eca91f1b7cce9a92be3892
+  ExpoModulesCore: a6fb0ff8f971a47c7c9f0d9dcf5a941158f97114
   ExpoSecureStore: 9c6571fe3fcb045a671c4011c451546eaaab98fd
   EXUpdatesInterface: 5adf50cb41e079c861da6d9b4b954c3db9a50734
   FBLazyVector: e95a291ad2dadb88e42b06e0c5fb8262de53ec12
@@ -2307,65 +2297,65 @@ SPEC CHECKSUMS:
   React-Core-prebuilt: 02f0ad625ddd47463c009c2d0c5dd35c0d982599
   React-CoreModules: 1f6d1744b5f9f2ec684a4bb5ced25370f87e5382
   React-cxxreact: 3af79478e8187b63ffc22b794cd42d3fc1f1f2da
-  React-debug: 6328c2228e268846161f10082e80dc69eac2e90a
-  React-defaultsnativemodule: d635ef36d755321e5d6fc065bd166b2c5a0e9833
-  React-domnativemodule: dd28f6d96cd21236e020be2eff6fe0b7d4ec3b66
-  React-Fabric: 2e32c3fdbb1fbcf5fde54607e3abe453c6652ce2
-  React-FabricComponents: 5ed0cdb81f6b91656cb4d3be432feaa28a58071a
-  React-FabricImage: 2bc714f818cb24e454f5d3961864373271b2faf8
-  React-featureflags: 847642f41fa71ad4eec5e0351badebcad4fe6171
-  React-featureflagsnativemodule: c868a544b2c626fa337bcbd364b1befe749f0d3f
-  React-graphics: 192ec701def5b3f2a07db2814dfba5a44986cff6
+  React-debug: dfe7f2f01b36058f2a9b94872e071eb40e063a3c
+  React-defaultsnativemodule: 414bc0a2e02166cd7fa0a41e104434935ae01708
+  React-domnativemodule: 9ec14a7fed0d3e4e76fd48e07d911f8934ab282d
+  React-Fabric: a2c0c50b9f0ea1f67e6b4bbde55589cacb8c3213
+  React-FabricComponents: 796f19e3beb5e44bcdd72bd4d8a5954d6a61d225
+  React-FabricImage: f75d4b23f449364c3aeae684cd2995c2be68149a
+  React-featureflags: 3285df1e581749640b797db0ab2120e9c6974da5
+  React-featureflagsnativemodule: 181e9aa5afcdbc27ca560a6872d9510e0f7d9179
+  React-graphics: 22b2dce86291d73fe7e37c7492d44865d9077a67
   React-hermes: e875778b496c86d07ab2ccaa36a9505d248a254b
-  React-idlecallbacksnativemodule: 4d57965cdf82c14ee3b337189836cd8491632b76
-  React-ImageManager: bd0b99e370b13de82c9cd15f0f08144ff3de079e
-  React-jserrorhandler: a2fdef4cbcfdcdf3fa9f5d1f7190f7fd4535248d
+  React-idlecallbacksnativemodule: db0dae0874018750aedb4f6f574d68c05c6478cd
+  React-ImageManager: c659ddac4e196a28cefd036f5881b2c355363882
+  React-jserrorhandler: 23a4e4e66c95a68300a4d01f359f9b8a5500aaa3
   React-jsi: 89d43d1e7d4d0663f8ba67e0b39eb4e4672c27de
   React-jsiexecutor: abe4874aaab90dfee5dec480680220b2f8af07e3
-  React-jsinspector: a0b3e051aef842b0b2be2353790ae2b2a5a65a8f
-  React-jsinspectorcdp: 6346013b2247c6263fbf5199adf4a8751e53bd89
-  React-jsinspectornetwork: 26281aa50d49fc1ec93abf981d934698fa95714f
-  React-jsinspectortracing: 55eedf6d57540507570259a778663b90060bbd6e
-  React-jsitooling: 0e001113fa56d8498aa8ac28437ac0d36348e51a
-  React-jsitracing: b713793eb8a5bbc4d86a84e9d9e5023c0f58cbaf
+  React-jsinspector: 91f19a57032075d0f820fdee080080a21c4afabe
+  React-jsinspectorcdp: 20537446838cf73f826cb1f78ec1180c58da6eb5
+  React-jsinspectornetwork: fc9a317f3a57c33da6252c9cc160d321b85a3a48
+  React-jsinspectortracing: 9dcf5dd0b7a4373704c4804cac75790b7d7977b4
+  React-jsitooling: 65c430d41f8df1e5014863dbc569068d0458359b
+  React-jsitracing: 12d9474cefa6ce0ac4d0affde93dddabb17ea343
   React-logger: 50fdb9a8236da90c0b1072da5c32ee03aeb5bf28
-  React-Mapbuffer: 9050ee10c19f4f7fca8963d0211b2854d624973e
-  React-microtasksnativemodule: f775db9e991c6f3b8ccbc02bfcde22770f96e23b
-  react-native-adapty-sdk: 0222ea5dc530924bb22d7f9fc8a33411cffcb5fa
-  react-native-safe-area-context: e4223e0c3d6770be30a9353ad2eaf99368b2f6e8
+  React-Mapbuffer: 0164bc6ba0866e6314d86851620e6f1f95a1b4fb
+  React-microtasksnativemodule: f5972fb404f7c363ff34b2292e72a716956c590c
+  react-native-adapty-sdk: 12e9ac151226eb50547df5ea882a66fcd2049273
+  react-native-safe-area-context: 735a79b36061761648c941bc4c8912c3d81719a4
   React-NativeModulesApple: 8969913947d5b576de4ed371a939455a8daf28aa
   React-oscompat: ce47230ed20185e91de62d8c6d139ae61763d09c
   React-perflogger: 02b010e665772c7dcb859d85d44c1bfc5ac7c0e4
-  React-performancetimeline: 130db956b5a83aa4fb41ddf5ae68da89f3fb1526
+  React-performancetimeline: bdad83ed66209c5cd252a38ed2c7b16c535c2286
   React-RCTActionSheet: 0b14875b3963e9124a5a29a45bd1b22df8803916
   React-RCTAnimation: a7b90fd2af7bb9c084428867445a1481a8cb112e
   React-RCTAppDelegate: 3262bedd01263f140ec62b7989f4355f57cec016
   React-RCTBlob: c17531368702f1ebed5d0ada75a7cf5915072a53
-  React-RCTFabric: 6409edd8cfdc3133b6cc75636d3b858fdb1d11ea
-  React-RCTFBReactNativeSpec: c004b27b4fa3bd85878ad2cf53de3bbec85da797
+  React-RCTFabric: 14cd088b95d6c00c9dadad25cf946fb1770cc898
+  React-RCTFBReactNativeSpec: 8948374e74e37e65923abfffeb12bf78e0aa7318
   React-RCTImage: c68078a120d0123f4f07a5ac77bea3bb10242f32
   React-RCTLinking: cf8f9391fe7fe471f96da3a5f0435235eca18c5b
   React-RCTNetwork: ca31f7c879355760c2d9832a06ee35f517938a20
-  React-RCTRuntime: a6cf4a1e42754fc87f493e538f2ac6b820e45418
+  React-RCTRuntime: 9669e40cc60ac65f09e75730e925c4a6a66debd4
   React-RCTSettings: e0e140b2ff4bf86d34e9637f6316848fc00be035
   React-RCTText: 75915bace6f7877c03a840cc7b6c622fb62bfa6b
   React-RCTVibration: 25f26b85e5e432bb3c256f8b384f9269e9529f25
-  React-rendererconsistency: 2dac03f448ff337235fd5820b10f81633328870d
-  React-renderercss: 477da167bb96b5ac86d30c5d295412fb853f5453
-  React-rendererdebug: 2a1798c6f3ef5f22d466df24c33653edbabb5b89
-  React-RuntimeApple: 28cf4d8eb18432f6a21abbed7d801ab7f6b6f0b4
-  React-RuntimeCore: 41bf0fd56a00de5660f222415af49879fa49c4f0
-  React-runtimeexecutor: 1afb774dde3011348e8334be69d2f57a359ea43e
-  React-RuntimeHermes: f3b158ea40e8212b1a723a68b4315e7a495c5fc6
-  React-runtimescheduler: 3e1e2bec7300bae512533107d8e54c6e5c63fe0f
-  React-timing: 6fa9883de2e41791e5dc4ec404e5e37f3f50e801
-  React-utils: 6e2035b53d087927768649a11a26c4e092448e34
+  React-rendererconsistency: 51d190444383ec3b4c87321c700d1f6513c751c9
+  React-renderercss: 876db927db3e30259c47be13bfa36d2c646b6c13
+  React-rendererdebug: c1056f8c458501ef6022a076d47bcc9fd1a84b01
+  React-RuntimeApple: 0766031d217ff53b8c5bb3a90a114c698890ccbb
+  React-RuntimeCore: b3c96e5eaa457d8f5680e7986d8694a8329bcfea
+  React-runtimeexecutor: d1f52523b0b66051e22be1aabd8dd5de1dbf5eef
+  React-RuntimeHermes: 2396631900bdb9fb05667de66345365d0d394e2b
+  React-runtimescheduler: 2032e7fa094a7494809b478ef4434588b5ab992a
+  React-timing: 32f695c27e3896d6f1bef77de042781b1bc999b3
+  React-utils: 9f498dae9ce2da37772ab680a37ba516a4ea0a7e
   ReactAppDependencyProvider: 1bcd3527ac0390a1c898c114f81ff954be35ed79
-  ReactCodegen: 7d4593f7591f002d137fe40cef3f6c11f13c88cc
+  ReactCodegen: 9a5f0d4c80fe9bb1ff29309a76392825aabe68c7
   ReactCommon: 08810150b1206cc44aecf5f6ae19af32f29151a8
   ReactNativeDependencies: 71ce9c28beb282aa720ea7b46980fff9669f428a
-  RNScreens: 61c18865ab074f4d995ac8d7cf5060522a649d05
-  Yoga: 3fd22c2cae22d7a2b0f0b538f55f7c2a17dc94d5
+  RNScreens: 30e3e86744e6dd0c46ebee546f7f79d70b382c69
+  Yoga: 218f04bb8b0ddbc0ac14ab1bc936236e0bf8ca4c
 
 PODFILE CHECKSUM: 823f7823fec1ee3d5d9b5540f3348010e90c5304
 

--- a/examples/FocusJournalExpo/ios/Podfile.properties.json
+++ b/examples/FocusJournalExpo/ios/Podfile.properties.json
@@ -1,5 +1,8 @@
 {
   "expo.jsEngine": "hermes",
   "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
-  "newArchEnabled": "true"
+  "newArchEnabled": "true",
+  "ios.useFrameworks": "dynamic",
+  "ios.forceStaticLinking": "[]",
+  "apple.privacyManifestAggregationEnabled": "true"
 }

--- a/examples/FocusJournalExpo/package-lock.json
+++ b/examples/FocusJournalExpo/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^7.1.10",
         "@react-navigation/native-stack": "^7.3.14",
         "expo": "~54.0.20",
+        "expo-build-properties": "~1.0.10",
         "expo-dev-client": "6.0.16",
         "expo-secure-store": "~15.0.7",
         "expo-status-bar": "~3.0.8",
@@ -3357,6 +3358,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -4642,6 +4659,19 @@
         }
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-1.0.10.tgz",
+      "integrity": "sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-dev-client": {
       "version": "6.0.16",
       "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.16.tgz",
@@ -5328,6 +5358,22 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6300,6 +6346,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",

--- a/examples/FocusJournalExpo/package.json
+++ b/examples/FocusJournalExpo/package.json
@@ -7,7 +7,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "update-sdk-full": "../../scripts/build_and_install_pack.zsh",
-    "update-native-modules": "cd ./ios && pod update Adapty AdaptyUI AdaptyPlugin",
+    "update-native-modules": "cd ./ios && pod install --repo-update",
     "ios:preview": "expo run:ios --configuration Release",
     "android:preview": "expo run:android --variant release"
   },
@@ -15,12 +15,13 @@
     "@react-navigation/native": "^7.1.10",
     "@react-navigation/native-stack": "^7.3.14",
     "expo": "~54.0.20",
+    "expo-build-properties": "~1.0.10",
     "expo-dev-client": "6.0.16",
     "expo-secure-store": "~15.0.7",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",
     "react-native": "0.81.5",
-    "react-native-adapty": "3.15.6",
+    "react-native-adapty": "3.17.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "4.18.0"
   },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "tslib": "^2.5.0"
   },
   "peerDependencies": {
-    "react-native": ">= 0.73.0"
+    "react-native": ">= 0.75.0"
   },
   "peerDependenciesMeta": {},
   "resolutions": {

--- a/react-native-adapty-sdk.podspec
+++ b/react-native-adapty-sdk.podspec
@@ -19,9 +19,20 @@ Pod::Spec.new do |s|
   s.resources = "ios/**/*.{plist}"
   s.requires_arc = true
 
-  s.dependency "Adapty", "3.17.0"
-  s.dependency "AdaptyUI", "3.17.0"
-  s.dependency "AdaptyPlugin", "3.17.0"
-  s.dependency "React"
-end
+  if defined?(:spm_dependency)
+    spm_dependency(s,
+      url: 'https://github.com/adaptyteam/AdaptySDK-iOS.git',
+      requirement: { kind: 'exactVersion', version: '3.17.0' },
+      products: ['Adapty', 'AdaptyUI', 'AdaptyPlugin']
+    )
+  else
+    raise "react-native-adapty 4.0.0+ requires React Native >= 0.75 for SPM-based native iOS dependencies. " \
+          "Upgrade React Native to >= 0.75, or use react-native-adapty 3.x (< 4.0.0)."
+  end
 
+  if respond_to?(:install_modules_dependencies, true)
+    install_modules_dependencies(s)
+  else
+    s.dependency "React-Core"
+  end
+end


### PR DESCRIPTION
As CocoaPods is reaching [end of life](https://blog.cocoapods.org/CocoaPods-Specs-Repo/), we will migrate our React Native SDK to Swift Package Manager.

- React Native 0.75 added support for SPM packages in React Native apps via the spm_dependency [helper](https://www.callstack.com/blog/integrating-swift-package-manager-with-react-native-libraries), which lets libraries use SPM packages together with CocoaPods.
- Using SPM packages inside React Native app currently forces the entire iOS project to adopt `use_frameworks! :linkage => :dynamic.`
- Minimum supported React Native version bumped from 0.73 to 0.75; minimum Expo version is 50.