### PR TITLE
feat(ios): Podfile helper to enable Kids Mode (SPM traits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,34 @@ Read the [documentation](https://adapty.io/docs/sdk-installation-reactnative?utm
 
   `spm_dependency` only works with dynamic frameworks. If you currently use the default static linkage you'll need to switch — be aware this can conflict with libraries that don't yet support modular headers (see the [Callstack write-up](https://www.callstack.com/blog/integrating-swift-package-manager-with-react-native-libraries)) and is incompatible with Flipper.
 
+### Kids Mode (iOS)
+
+If your app targets the App Store Kids Category (or must comply with COPPA), the native iOS SDK must be built with the `KidsMode` Swift package trait, which compiles out all IDFA / AdSupport / AppTrackingTransparency code. React Native's `spm_dependency` cannot forward package traits, so the SDK ships a Podfile helper that applies the trait for you.
+
+In your `ios/Podfile`, require the helper and call it **after** `react_native_post_install`:
+
+```ruby
+require Pod::Executable.execute_command('node', ['-p',
+  'require.resolve(
+    "react-native-adapty/ios/adapty_kids_mode.rb",
+    {paths: [process.argv[1]]},
+  )', __dir__]).strip
+
+# ...
+
+post_install do |installer|
+  react_native_post_install(
+    installer,
+    config[:reactNativePath],
+    :mac_catalyst_enabled => false
+  )
+
+  adapty_enable_kids_mode(installer)
+end
+```
+
+Then run `pod install`. To verify, check that the `Adapty.activate(...)` log line reports `kids_mode_enabled: true`. The helper must stay in `post_install` permanently — React Native recreates the Swift package references on every `pod install`, and the helper re-applies the trait each time.
+
 ## Integrate IAPs within a few hours without server coding
 
 **Adapty handles everything, from free trials to refunds, in a simple, developer-friendly SDK.**

--- a/ios/adapty_kids_mode.rb
+++ b/ios/adapty_kids_mode.rb
@@ -1,0 +1,65 @@
+# Enables Adapty Kids Mode (COPPA / App Store Kids Category) for the native
+# iOS SDK installed through the `spm_dependency` helper in
+# react-native-adapty-sdk.podspec.
+#
+# AdaptySDK-iOS 4.x ships Kids Mode as a Swift package trait (`KidsMode`) that
+# compiles out all IDFA / AdSupport / AppTrackingTransparency code. React
+# Native's `spm_dependency` cannot forward package traits, so this helper sets
+# the trait directly on the Swift package reference that `spm_dependency`
+# creates inside the generated Pods project — the same `traits` pbxproj
+# attribute Xcode writes when a trait is enabled in the Package Dependencies
+# inspector. Xcode 26+ is required, which is already the floor for
+# AdaptySDK-iOS 4.x (its manifest uses swift-tools-version 6.2).
+#
+# Usage (ios/Podfile):
+#
+#   require Pod::Executable.execute_command('node', ['-p',
+#     'require.resolve(
+#       "react-native-adapty/ios/adapty_kids_mode.rb",
+#       {paths: [process.argv[1]]},
+#     )', __dir__]).strip
+#
+#   post_install do |installer|
+#     react_native_post_install(installer, ...)
+#     adapty_enable_kids_mode(installer) # AFTER react_native_post_install
+#   end
+#
+# The call must come after `react_native_post_install`: React Native's SPM
+# integration wipes and recreates all package references in the Pods project
+# on every `pod install`, so the trait has to be (re)applied afterwards.
+#
+# Verify it worked: the `Adapty.activate(...)` system log reports
+# `kids_mode_enabled: true`, and the pbxproj block for AdaptySDK-iOS in
+# `ios/Pods/Pods.xcodeproj/project.pbxproj` contains `traits = (KidsMode,);`.
+
+ADAPTY_IOS_PACKAGE_REPO = 'AdaptySDK-iOS'.freeze
+ADAPTY_KIDS_MODE_TRAIT = 'KidsMode'.freeze
+
+def adapty_enable_kids_mode(installer)
+  ref_class = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference
+
+  # xcodeproj (<= 1.27) doesn't model the `traits` attribute Xcode uses to
+  # store enabled package traits, so declare it; assignment then validates and
+  # serializes into the pbxproj like any native attribute. The attribute lists
+  # are memoized per class, so reset them after registering.
+  unless ref_class.attributes.any? { |attrb| attrb.name == :traits }
+    ref_class.send(:attribute, :traits, Array)
+    ref_class.instance_variable_set(:@full_attributes, nil)
+    ref_class.instance_variable_set(:@simple_attributes, nil)
+  end
+
+  refs = installer.pods_project.root_object.package_references.select do |ref|
+    ref.is_a?(ref_class) && ref.repositoryURL.to_s.include?(ADAPTY_IOS_PACKAGE_REPO)
+  end
+
+  if refs.empty?
+    Pod::UI.warn "[Adapty] Kids Mode NOT enabled: no #{ADAPTY_IOS_PACKAGE_REPO} Swift package reference found " \
+                 'in the Pods project. Call adapty_enable_kids_mode(installer) AFTER react_native_post_install(...).'
+    return
+  end
+
+  refs.each do |ref|
+    ref.traits = [ADAPTY_KIDS_MODE_TRAIT]
+    Pod::UI.puts "[Adapty] Kids Mode enabled: #{ADAPTY_KIDS_MODE_TRAIT} trait set on #{ref.repositoryURL}"
+  end
+end


### PR DESCRIPTION
## Problem

AdaptySDK-iOS 4.x ships Kids Mode (COPPA / App Store Kids Category) as a Swift package trait `KidsMode`, which compiles out all IDFA / AdSupport / AppTrackingTransparency code. React Native installs the native SDK through the `spm_dependency` podspec helper, which cannot forward package traits — so RN apps had no way to enable Kids Mode.

## Solution

New `ios/adapty_kids_mode.rb` (ships in the npm package): a Podfile `post_install` helper that sets the `traits` pbxproj attribute on the AdaptySDK-iOS Swift package reference created by `spm_dependency` — the same attribute Xcode writes when a trait is enabled in the Package Dependencies inspector. Requires Xcode 26+, which is already the floor for AdaptySDK-iOS 4.x (swift-tools-version 6.2).

Implementation notes:
- The `xcodeproj` gem (<= 1.27) doesn't model the `traits` attribute, so the helper registers it at runtime and resets the gem's memoized attribute lists (without the reset the value is assigned but silently dropped on serialization).
- Must be called **after** `react_native_post_install`: RN's SPM integration wipes and recreates all package references on every `pod install`, so the trait is re-applied each run.

Usage (documented in README):

```ruby
require Pod::Executable.execute_command('node', ['-p',
  'require.resolve(
    "react-native-adapty/ios/adapty_kids_mode.rb",
    {paths: [process.argv[1]]},
  )', __dir__]).strip

post_install do |installer|
  react_native_post_install(installer, config[:reactNativePath])
  adapty_enable_kids_mode(installer)
end
```

## Verification

- `pod install` (twice — idempotent): `traits = (KidsMode,)` lands on the package reference in `Pods.xcodeproj`, helper logs `[Adapty] Kids Mode enabled`.
- `xcodebuild` on the RN devtools app: `-DKidsMode` present in all 6 package module compilations (Adapty, AdaptyCodable, AdaptyLogger, AdaptyPlugin, AdaptyUI, AdaptyUIBuilder) and nowhere else; AdSupport not linked into the SDK framework.
- Without the helper call (normal mode), a device build (`-sdk iphoneos`) links AdSupport / AdServices / AppTrackingTransparency via Swift autolink as before; runtime activation reports `kids_mode_enabled: true/false` accordingly (checked on a real device).
