### PR TITLE
fix(ui): default flow permission reply to 'denied'

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@adapty/core": "4.0.0-beta.1-dev.e467e14ee232001393e8b37ac05fc9d6906a8e4a",
+    "@adapty/core": "4.0.0-beta.1-dev.7b097766c96f29ef0f7f84992f65de4c17b6c275",
     "tslib": "^2.5.0"
   },
   "peerDependencies": {

--- a/src/__tests__/integration/ui/flow/events/flow-view-controller-events.test.ts
+++ b/src/__tests__/integration/ui/flow/events/flow-view-controller-events.test.ts
@@ -297,7 +297,7 @@ describe('FlowViewController - action mapping isolation', () => {
     requestSpy.mockRestore();
   });
 
-  it('replies with unavailable when onRequestPermission rejects', async () => {
+  it('replies with denied when onRequestPermission rejects', async () => {
     const requestSpy = jest
       .spyOn(($bridge as any).testBridge, 'request')
       .mockResolvedValue(undefined);
@@ -333,7 +333,7 @@ describe('FlowViewController - action mapping isolation', () => {
     expect(body).toMatchObject({
       method: 'flow_view_did_answer_permission',
       event_id: 'evt-err',
-      status: 'unavailable',
+      status: 'denied',
     });
 
     requestSpy.mockRestore();

--- a/src/ui/flow-view-emitter.ts
+++ b/src/ui/flow-view-emitter.ts
@@ -245,7 +245,7 @@ export class FlowViewEmitter {
     const handler =
       handlerData.handler as FlowEventHandlers['onRequestPermission'];
 
-    let status: FlowPermissionStatus = 'unavailable';
+    let status: FlowPermissionStatus = 'denied';
     let detail: string | undefined;
     try {
       const response = await handler(event.permission, event.customArgs);

--- a/src/ui/types.test.ts
+++ b/src/ui/types.test.ts
@@ -73,7 +73,7 @@ describe('DEFAULT_FLOW_EVENT_HANDLERS — native-delegating defaults', () => {
   });
 
   describe('onRequestPermission', () => {
-    it('warns and replies `unavailable` (no real default exists)', async () => {
+    it('warns and replies `denied` (no real default exists)', async () => {
       const warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
 
       const result = await DEFAULT_FLOW_EVENT_HANDLERS.onRequestPermission(
@@ -82,7 +82,7 @@ describe('DEFAULT_FLOW_EVENT_HANDLERS — native-delegating defaults', () => {
       );
 
       expect(warnSpy).toHaveBeenCalled();
-      expect(result).toEqual({ status: 'unavailable' });
+      expect(result).toEqual({ status: 'denied' });
     });
   });
 

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -81,17 +81,17 @@ export const DEFAULT_FLOW_EVENT_HANDLERS: FlowEventHandlers = {
   onAnalytics: () => false,
   // There is no real default here: permissions must be declared in the app
   // bundle by the developer, so we cannot grant them on the user's behalf. Warn
-  // and reply `unavailable` so native always gets a correlated answer.
+  // and reply `denied` so native always gets a correlated answer.
   onRequestPermission: async () => {
     Log.warn(
       'onRequestPermission',
       () =>
-        'No onRequestPermission handler provided; replying `unavailable`. ' +
+        'No onRequestPermission handler provided; replying `denied`. ' +
         'Declare the required permissions in your app bundle and provide an ' +
         'onRequestPermission handler to respond.',
     );
 
-    return { status: 'unavailable' as const };
+    return { status: 'denied' as const };
   },
   // Observer mode: no real default. If you enable observer mode and present a
   // flow view, you must drive the purchase/restore yourself, so warn when no

--- a/src/ui/use-flow-event-subscription.test.ts
+++ b/src/ui/use-flow-event-subscription.test.ts
@@ -102,7 +102,7 @@ describe('useFlowEventSubscription', () => {
 
   it('preserves the async onRequestPermission return value', async () => {
     const handler = jest.fn(async () => ({
-      status: 'unavailable' as const,
+      status: 'denied' as const,
       detail: 'from-test',
     }));
     act(() => {
@@ -117,7 +117,7 @@ describe('useFlowEventSubscription', () => {
           detail?: string;
         }>
       )(),
-    ).resolves.toEqual({ status: 'unavailable', detail: 'from-test' });
+    ).resolves.toEqual({ status: 'denied', detail: 'from-test' });
     expect(handler).toHaveBeenCalledTimes(1);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz#296d00581bfaaabfda1e976849d927824aaea81b"
   integrity sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==
 
-"@adapty/core@4.0.0-beta.1-dev.e467e14ee232001393e8b37ac05fc9d6906a8e4a":
-  version "4.0.0-beta.1-dev.e467e14ee232001393e8b37ac05fc9d6906a8e4a"
-  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-beta.1-dev.e467e14ee232001393e8b37ac05fc9d6906a8e4a.tgz#61913de6e59f045e543506a6c7d4645b38576390"
-  integrity sha512-KA+RTFpxK+Vp1L4/sT0Wyj0RHKQDBFXSKNshYGMtFnZEuEALRGbjTa70Yvm0eKRWyzrQNLqeQPMR1eTRTSek3Q==
+"@adapty/core@4.0.0-beta.1-dev.7b097766c96f29ef0f7f84992f65de4c17b6c275":
+  version "4.0.0-beta.1-dev.7b097766c96f29ef0f7f84992f65de4c17b6c275"
+  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-beta.1-dev.7b097766c96f29ef0f7f84992f65de4c17b6c275.tgz#57c9a625a1648c6ec42ad6af1cd8a332c515f584"
+  integrity sha512-Mm1gSsvFdD/k/4BgBzrOwh5Yxs98ARdYcQPggXOX6z1/uO28eE6JdBseYwxWYLlWRvhwWSrhzyQNO3CGCH2Zzg==
   dependencies:
     tslib "^2.5.0"
 
@@ -6328,6 +6328,7 @@ string-length@^4.0.1:
     strip-ansi "^6.0.0"
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6793,6 +6794,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
The wire contract dropped the 'unavailable' permission status (flow_view_did_answer_permission enum is now granted|denied). Reply 'denied' when no onRequestPermission handler is provided or the handler rejects, so native always gets a valid correlated answer.