### PR TITLE
refactor(ui): nest flow-view enableSafeArea under android key

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "typescript": "5.1.6"
   },
   "dependencies": {
-    "@adapty/core": "4.0.0-beta.1",
+    "@adapty/core": "4.0.0-beta.2-dev.b3e54b2b655ae5ce2d0dd0b96fe1e0135ef200ea",
     "tslib": "^2.5.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "react-native-adapty",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.2",
   "description": "Adapty React Native SDK",
   "license": "MIT",
   "author": "Adapty team <support@adapty.io>",

--- a/src/__tests__/integration/ui/flow/methods/flow-view-controller-methods.test.ts
+++ b/src/__tests__/integration/ui/flow/methods/flow-view-controller-methods.test.ts
@@ -84,7 +84,7 @@ describe('FlowViewController Methods (Bridge Integration)', () => {
       await createFlowView(flow, {
         prefetchProducts: false,
         loadTimeoutMs: 3000,
-        enableSafeArea: false,
+        android: { enableSafeArea: false },
       });
 
       const request = extractNativeRequest<

--- a/src/ui/AdaptyFlowView.safe-area.test.tsx
+++ b/src/ui/AdaptyFlowView.safe-area.test.tsx
@@ -25,7 +25,7 @@ describe('AdaptyFlowView safe-area paddings', () => {
     mockEncodeParams.mockClear();
   });
 
-  it('defaults enableSafeArea to false when the prop is unset', () => {
+  it('defaults android.enableSafeArea to false when the prop is unset', () => {
     act(() => {
       renderer.create(
         <AdaptyFlowView flow={flow} params={{ prefetchProducts: false }} />,
@@ -33,19 +33,22 @@ describe('AdaptyFlowView safe-area paddings', () => {
     });
 
     expect(mockEncodeParams).toHaveBeenCalledWith(
-      expect.objectContaining({ enableSafeArea: false }),
+      expect.objectContaining({ android: { enableSafeArea: false } }),
     );
   });
 
-  it('respects a caller-supplied enableSafeArea override', () => {
+  it('respects a caller-supplied android.enableSafeArea override', () => {
     act(() => {
       renderer.create(
-        <AdaptyFlowView flow={flow} params={{ enableSafeArea: true }} />,
+        <AdaptyFlowView
+          flow={flow}
+          params={{ android: { enableSafeArea: true } }}
+        />,
       );
     });
 
     expect(mockEncodeParams).toHaveBeenCalledWith(
-      expect.objectContaining({ enableSafeArea: true }),
+      expect.objectContaining({ android: { enableSafeArea: true } }),
     );
   });
 });

--- a/src/ui/AdaptyFlowView.tsx
+++ b/src/ui/AdaptyFlowView.tsx
@@ -23,7 +23,9 @@ import { AdaptyFlowViewMock } from './AdaptyFlowView.mock';
  */
 const COMPONENT_DEFAULT_PARAMS: CreateFlowViewParamsInput = {
   ...DEFAULT_PARAMS,
-  enableSafeArea: false,
+  android: {
+    enableSafeArea: false,
+  },
 };
 
 /**

--- a/src/ui/flow-view-controller.ts
+++ b/src/ui/flow-view-controller.ts
@@ -20,7 +20,9 @@ import { Req } from '@/types/schema';
 export const DEFAULT_PARAMS: CreateFlowViewParamsInput = {
   prefetchProducts: true,
   loadTimeoutMs: 5000,
-  enableSafeArea: true,
+  android: {
+    enableSafeArea: true,
+  },
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz#296d00581bfaaabfda1e976849d927824aaea81b"
   integrity sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==
 
-"@adapty/core@4.0.0-beta.1":
-  version "4.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-beta.1.tgz#e47c9d0210c7fac2a51085dfd0678cb6899d756e"
-  integrity sha512-kku+W9pt0jMCYSIrYoQoOFqeSbYBpJIMokrPZevQujTAqGnWDbSq5WlyKA2NlpvuBfnottf/R3BoyULNSEM7LA==
+"@adapty/core@4.0.0-beta.2-dev.b3e54b2b655ae5ce2d0dd0b96fe1e0135ef200ea":
+  version "4.0.0-beta.2-dev.b3e54b2b655ae5ce2d0dd0b96fe1e0135ef200ea"
+  resolved "https://registry.yarnpkg.com/@adapty/core/-/core-4.0.0-beta.2-dev.b3e54b2b655ae5ce2d0dd0b96fe1e0135ef200ea.tgz#dd00c5d7d7f1132ea507143dc0b390410e4ec8b2"
+  integrity sha512-kZgzsMY1AxxQTKh07KCtFtorAzFFM5IVWjo6gh1sTK98f7ap+ukQMn8B20Kotshy/Bxc3v2onrsBDZdyHdJYKQ==
   dependencies:
     tslib "^2.5.0"
 


### PR DESCRIPTION
Follow @adapty/core: the Android-only enableSafeArea option now lives under a nested android?: {} object. Update DEFAULT_PARAMS, the embedded component defaults, and the related tests.