### PR TITLE
ci(publish): add 'latest-3' npm dist-tag option for v3 legacy fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
         options:
           - 'latest'
           - 'beta'
+          - 'latest-3'  # legacy channel for v3.x fixes (keeps 'latest' on v4+)
       dry-run:
         description: 'Perform a dry run (no actual publish)'
         required: false


### PR DESCRIPTION
Publishing a v3.x patch must not move the 'latest' dist-tag (currently on v4). Add a dedicated 'latest-3' channel so legacy fixes land under 'react-native-adapty@latest-3' while 'latest' stays on v4+.