### PR TITLE
fix(ios): make the spm_dependency availability guard actually work

### DIFF
--- a/react-native-adapty-sdk.podspec
+++ b/react-native-adapty-sdk.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.resources = "ios/**/*.{plist}"
   s.requires_arc = true
 
-  if defined?(:spm_dependency)
+  if defined?(spm_dependency)
     spm_dependency(s,
       url: 'https://github.com/adaptyteam/AdaptySDK-iOS.git',
       requirement: { kind: 'exactVersion', version: '4.0.2' },


### PR DESCRIPTION
`defined?(:spm_dependency)` passes a symbol literal, which `defined?` always reports as "expression", so the guard was truthy on every React Native version and the else branch was dead code. On React Native < 0.75 (or any evaluation where react_native_pods.rb is not loaded) the podspec failed with a bare `undefined method 'spm_dependency' for Pod:Module` instead of the intended upgrade instructions.

Dropping the colon makes `defined?` check the method itself. Behaviour on the supported path is unchanged: with react_native_pods.rb loaded the spec still registers the same SPM package reference.