### PR TITLE
fix(android): exclude android/bin, android/gen and android/out

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,13 @@
     "!ios/RNAdapty.xcodeproj/xcuserdata",
     "*.podspec",
     "android/",
+    "!android/bin",
     "!android/build",
+    "!android/gen",
     "!android/gradle",
     "!android/gradlew*",
     "!android/local.properties",
+    "!android/out",
     "plugin/build/",
     "app.plugin.js",
     "!**/.*"


### PR DESCRIPTION
…. CI publishing is not affected.

Exclude android/bin, android/gen and android/out — the android artifact dirs .gitignore already declares as junk. The existing `!android/build` and `!android/gradle` entries do not cover the nested paths under them.