### PR TITLE
chore: upgrade ios SDK to 4.1.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(name: "ReactNative", path: "../../../../xcframeworks"),
         .package(
             url: "https://github.com/adaptyteam/AdaptySDK-iOS.git",
-            branch: "hotfix/4.1.3",
+            exact: "4.1.3",
             traits: [
                 .defaults,
                 .trait(name: "KidsMode", condition: .when(traits: ["AdaptyReactNativeKidsMode"]))

--- a/examples/AdaptyDevtools/ios/AdaptyRnSdkExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/examples/AdaptyDevtools/ios/AdaptyRnSdkExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/adaptyteam/AdaptySDK-iOS.git",
       "state" : {
-        "branch" : "hotfix/4.1.3",
-        "revision" : "8d0ed9e0e2c2865479f5c0bf0ad97b828b461de2"
+        "revision" : "8d0ed9e0e2c2865479f5c0bf0ad97b828b461de2",
+        "version" : "4.1.3"
       }
     }
   ],

--- a/react-native-adapty-sdk.podspec
+++ b/react-native-adapty-sdk.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   if defined?(spm_dependency)
     spm_dependency(s,
       url: 'https://github.com/adaptyteam/AdaptySDK-iOS.git',
-      requirement: { kind: 'branch', branch: 'hotfix/4.1.3' },
+      requirement: { kind: 'exactVersion', version: '4.1.3' },
       products: ['Adapty', 'AdaptyUI', 'AdaptyPlugin']
     )
   else


### PR DESCRIPTION
4.1.3 is released, so replace the temporary hotfix/4.1.3 branch pin with the tag on both integration paths. The tag points at the same revision the branch did (8d0ed9e), so this changes how the dependency resolves, not what it builds.