### PR TITLE
ci: add publish-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,60 @@
+name: Publish docs
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Publish to npm
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    name: Publish docs
+    # A publish run is only a real publish when it came from a v* tag (see publish.yml's
+    # guard job) — this keeps dry runs from deploying docs to production.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          # On workflow_run the default ref is the default branch, so pin the commit
+          # the publish run used (the v* tag). Empty on workflow_dispatch — checkout
+          # then falls back to the dispatched ref.
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        id: cache-node-modules
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            node-modules-${{ runner.os }}-
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: Update versions
+        run: yarn update-versions
+
+      - name: Generate documentation
+        run: yarn doc-gen
+
+      - name: Publish docs to Netlify
+        run: yarn doc-deploy
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "publish-git": "./scripts/git-package_publish.zsh",
     "prepack": "yarn update-versions && yarn format-check && yarn tsc && yarn lint && yarn test && yarn build",
     "prepublishOnly": "yarn prepack",
-    "doc-gen": "typedoc --out docs src/__docs__.ts"
+    "doc-gen": "typedoc --out docs src/__docs__.ts",
+    "doc-deploy": "npx --yes netlify-cli@23.15.1 deploy --dir=docs --prod"
   },
   "devDependencies": {
     "@babel/core": "^7.22.9",


### PR DESCRIPTION
generate typedoc output and deploy it to Netlify after a successful npm publish (or on manual dispatch). Adds a doc-deploy script that runs the pinned netlify-cli via npx.